### PR TITLE
DataFrame concatenation to use pd.concat instead of append

### DIFF
--- a/chapter_06/adversarial-validation-example.ipynb
+++ b/chapter_06/adversarial-validation-example.ipynb
@@ -103,7 +103,7 @@
    },
    "outputs": [],
    "source": [
-    "X = train.append(test)\n",
+    "X = pd.concat([train, test], ignore_index=True)\n",
     "y = [0] * len(train) + [1] * len(test)"
    ]
   },


### PR DESCRIPTION
## Description:
This commit updates the DataFrame concatenation method from append to pd.concat due to the deprecation and removal of the append method in recent versions of pandas.

## Changes:
Replaced train.append(test) with pd.concat([train, test], ignore_index=True)
## Benefits:
Ensures compatibility with recent and future versions of pandas
Improves code stability and reduces the risk of encountering deprecated method errors
## Testing:
Verified that the concatenation works as expected and the combined DataFrame X is created correctly.
## Notes:
No changes in functionality or data processing logic, only an update to use the supported method for concatenation.